### PR TITLE
add +-button font-size

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -249,6 +249,7 @@ html, body {
     background-color: var(--bg-secondary);
     color: var(--accent);
     border: 1px solid var(--accent);
+    font-size: medium;
   }
   
 .board h1{


### PR DESCRIPTION
スマホでズームボタンをタップしたときに、画面ごとズームしてしまう問題を解決しました。buttonのフォントサイズを16pxに変更しただけです。（ブランチを間違えて消してしまい再送しました）